### PR TITLE
global: fix initial query state values

### DIFF
--- a/src/lib/storeConfig.js
+++ b/src/lib/storeConfig.js
@@ -7,14 +7,14 @@
  */
 
 export const INITIAL_STORE_STATE = {
-    queryString: '',
-    suggestions: [],
-    sortBy: null,
-    sortOrder: null,
-    page: 1,
-    size: 10,
-    filters: [],
-    layout: null,
-  };
+  queryString: '',
+  suggestions: [],
+  sortBy: null,
+  sortOrder: null,
+  page: -1,
+  size: -1,
+  filters: [],
+  layout: null,
+};
 
 export const STORE_KEYS = Object.keys(INITIAL_STORE_STATE);


### PR DESCRIPTION
The initial values for pagination and results per page should be "undefined" as the others, so that:
* if the ResultsPerPage or Pagination components are not mounted, the value stays undefined and it is not added to the query string sent to the backend
* if the components are mounted, then the `defaultValue` of the component will be set