### PR TITLE
aggs: remove valueLabels property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+Version 1.0.0-alpha.7 (released 2020-10-20)
+
+* Override query state from search response.
+* `InvenioSearchApi` extracts overriden state from response.
+* Configure `Sort` component to disable the order option.
+* Remove `valuesLabels` prop from `BucketAggregation` component.
+
 Version 1.0.0-alpha.6 (released 2020-10-15)
 
 * Override query state from search response.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-searchkit",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "description": "React components to build your search UI application",
   "main": "dist/cjs/index.js",
   "browser": "dist/cjs/index.js",

--- a/src/lib/components/BucketAggregation/BucketAggregation.js
+++ b/src/lib/components/BucketAggregation/BucketAggregation.js
@@ -27,7 +27,7 @@ class BucketAggregation extends Component {
   };
 
   _renderValues = (resultBuckets, selectedFilters) => {
-    const { overridableId, valuesLabels } = this.props;
+    const { overridableId } = this.props;
     return (
       <BucketAggregationValues
         buckets={resultBuckets}
@@ -37,7 +37,6 @@ class BucketAggregation extends Component {
         childAgg={this.agg.childAgg}
         onFilterClicked={this.onFilterClicked}
         overridableId={overridableId}
-        valuesLabels={valuesLabels}
       />
     );
   };
@@ -90,10 +89,6 @@ BucketAggregation.propTypes = {
   updateQueryFilters: PropTypes.func.isRequired,
   renderValuesContainerElement: PropTypes.func,
   renderValueElement: PropTypes.func,
-  valuesLabels: PropTypes.arrayOf(PropTypes.shape({
-      value: PropTypes.string.isRequired,
-      label: PropTypes.string.isRequired,
-  })),
   overridableId: PropTypes.string,
 };
 

--- a/src/lib/components/BucketAggregation/BucketAggregationValues.js
+++ b/src/lib/components/BucketAggregation/BucketAggregationValues.js
@@ -63,7 +63,7 @@ class BucketAggregationValues extends Component {
   };
 
   render() {
-    const { buckets, selectedFilters, valuesLabels, overridableId } = this.props;
+    const { buckets, selectedFilters, overridableId } = this.props;
     const valuesCmp = buckets.map((bucket) => {
       const isSelected = this._isSelected(
         this.aggName,
@@ -76,13 +76,7 @@ class BucketAggregationValues extends Component {
       const getChildAggCmps = (bucket) =>
         this.getChildAggCmps(bucket, selectedFilters);
       let label = null;
-      if(valuesLabels){
-        label = _get(
-          valuesLabels.find(e => e.value === bucket.key  ),
-          'label',
-          bucket.key
-        );
-      }
+
       return (
         <ValueElement
           key={bucket.key}
@@ -90,7 +84,6 @@ class BucketAggregationValues extends Component {
           isSelected={isSelected}
           onFilterClicked={onFilterClicked}
           getChildAggCmps={getChildAggCmps}
-          valueLabel={label}
           overridableId={overridableId}
         />
       );
@@ -125,11 +118,12 @@ const ValueElement = (props) => {
     isSelected,
     onFilterClicked,
     getChildAggCmps,
-    valueLabel,
     overridableId,
   } = props;
 
-  const label = valueLabel ? valueLabel : `${bucket.key} (${bucket.doc_count})`;
+  const label = bucket.label
+    ? bucket.label
+    : `${bucket.key} (${bucket.doc_count})`;
   const childAggCmps = getChildAggCmps(bucket);
   return (
     <Overridable
@@ -149,14 +143,15 @@ const ValueElement = (props) => {
   );
 };
 
-const ContainerElement = ({ valuesCmp, overridableId, valueLabel }) => {
-  return <Overridable
+const ContainerElement = ({ valuesCmp, overridableId }) => {
+  return (
+    <Overridable
       id={buildUID('BucketAggregationContainer.element', overridableId)}
       valuesCmp={valuesCmp}
-      valueLabel={valueLabel}
-  >
-    <List>{valuesCmp}</List>
-  </Overridable>
+    >
+      <List>{valuesCmp}</List>
+    </Overridable>
+  );
 };
 
 export default Overridable.component(


### PR DESCRIPTION
* You can override the `agg.bucket` label by injecting a `label` key to
  the `agg.buckets` items