### PR TITLE
fix url not updating state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-searchkit",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/api/UrlHandlerApi.js
+++ b/src/lib/api/UrlHandlerApi.js
@@ -158,11 +158,22 @@ export class UrlHandlerApi {
         }
       });
 
+    const keyComparator = (a, b) => {
+      const q = 'q'; // query parameter should appear first
+      if (a === q) {
+        return -1;
+      } else if (b === q) {
+        return 1;
+      }
+      return a.localeCompare(b);
+    }
+
     // will omit undefined and null values from the query
     return Qs.stringify(params, {
       addQueryPrefix: true,
       skipNulls: true,
       indices: false, // order for filters params is not important, remove indices
+      sort: keyComparator,
     });
   };
 
@@ -220,9 +231,7 @@ export class UrlHandlerApi {
   _mergeParamsIntoState = (urlStateObj, queryState) => {
     const _queryState = _cloneDeep(queryState);
     Object.keys(urlStateObj).forEach((stateKey) => {
-      if (stateKey in _queryState) {
-        _queryState[stateKey] = urlStateObj[stateKey];
-      }
+      _queryState[stateKey] = urlStateObj[stateKey];
     });
     return _queryState;
   };

--- a/src/lib/components/Bootstrap/index.js
+++ b/src/lib/components/Bootstrap/index.js
@@ -8,17 +8,16 @@
 
 import { connect } from 'react-redux';
 import {
-  executeQuery,
   onAppInitialized as _onAppInitialized,
   updateQueryState,
+  updateQueryStateFromUrl,
 } from '../../state/actions';
 import BootstrapComponent from './Bootstrap';
 
 const mapDispatchToProps = (dispatch) => ({
   onAppInitialized: (searchOnInit) => dispatch(_onAppInitialized(searchOnInit)),
   updateQueryState: (queryState) => dispatch(updateQueryState(queryState)),
-  searchOnUrlQueryStringChanged: () =>
-    dispatch(executeQuery({ shouldUpdateUrlQueryString: false })),
+  searchOnUrlQueryStringChanged: () => dispatch(updateQueryStateFromUrl()),
 });
 
 export const Bootstrap = connect(null, mapDispatchToProps)(BootstrapComponent);

--- a/src/lib/state/actions/query.js
+++ b/src/lib/state/actions/query.js
@@ -242,7 +242,7 @@ export const executeQuery = ({
       shouldUpdateUrlQueryString
     );
 
-    dispatch({ type: RESULTS_LOADING });
+    dispatch({ type: RESULTS_LOADING, payload: { queryState } });
     try {
       const response = await searchApi.search(queryState);
       if ('newQueryState' in response) {
@@ -255,11 +255,17 @@ export const executeQuery = ({
           aggregations: response.aggregations,
           hits: response.hits,
           total: response.total,
+          queryState,
         },
       });
     } catch (reason) {
       console.error(reason);
-      dispatch({ type: RESULTS_FETCH_ERROR, payload: reason });
+      dispatch({
+        type: RESULTS_FETCH_ERROR,
+        payload: {
+          error: reason,
+          queryState,
+        } });
     }
   };
 };
@@ -301,5 +307,18 @@ export const clearSuggestions = () => {
         suggestions: [],
       },
     });
+  };
+};
+
+export const updateQueryStateFromUrl = () => {
+  return (dispatch, getState, config) => {
+    if (config.urlHandlerApi) {
+      const newState = config.urlHandlerApi.get(config.initialQueryState);
+      dispatch({
+        type: SET_QUERY_STATE,
+        payload: newState,
+      });
+      dispatch(executeQuery({ shouldReplaceUrlQueryString: true }));
+    }
   };
 };

--- a/src/lib/state/reducers/query.js
+++ b/src/lib/state/reducers/query.js
@@ -6,7 +6,7 @@
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
-import { INITIAL_QUERY_STATE_KEYS } from '../../storeConfig';
+import { INITIAL_QUERY_STATE, INITIAL_QUERY_STATE_KEYS } from '../../storeConfig';
 import { updateQueryFilters, updateQueryState } from '../selectors';
 import {
   CLEAR_QUERY_SUGGESTIONS,
@@ -92,7 +92,8 @@ export default (state = {}, action) => {
     case SET_QUERY_STATE:
       return {
         ...state,
-        ...updateQueryState(state, action.payload, INITIAL_QUERY_STATE_KEYS),
+        ...INITIAL_QUERY_STATE,
+        ...updateQueryState(INITIAL_QUERY_STATE, action.payload, INITIAL_QUERY_STATE_KEYS),
       };
     case RESULTS_UPDATE_LAYOUT:
       return {


### PR DESCRIPTION
* fixes url history not updating the internal state
* closes inveniosoftware/react-invenio-app-ils#274

Tested on zenodo demo and on ILS. Also tested on CDS videos demo which has disabled support for url handling.

It may not be the best way to do it, but it works. I'm preventing the url from being updated twice: this is a workaround (I hope temporary) because the url is replaced twice, and even though the state is equivalent in both cases the order of the attributes is not.

Open to suggestions.