### PR TITLE
fix sort state

### DIFF
--- a/src/lib/api/UrlHandlerApi.js
+++ b/src/lib/api/UrlHandlerApi.js
@@ -220,6 +220,9 @@ export class UrlHandlerApi {
           result[queryStateKey] = urlParamsObj[paramKey].map((filter) =>
             this._filterStringToList(filter)
           );
+        } else if (queryStateKey === 'sortBy') {
+          // sorting was explicitly set in the url
+          result._sortUserChanged = true;
         }
       } else {
         console.warn(`URL parameter '${paramKey}' with value '${urlParamsObj[paramKey]}' is incorrect and was ignored.`);

--- a/src/lib/api/UrlHandlerApi.js
+++ b/src/lib/api/UrlHandlerApi.js
@@ -147,6 +147,9 @@ export class UrlHandlerApi {
         }
         return queryState[stateKey] !== null;
       })
+      .filter((stateKey) =>
+        (stateKey !== 'sortBy' && stateKey !== 'sortOrder') || queryState._userHasChangedSorting
+      )
       .forEach((stateKey) => {
         const paramKey = this.urlParamsMapping[stateKey];
         if (stateKey === 'filters') {
@@ -207,6 +210,7 @@ export class UrlHandlerApi {
    */
   _mapUrlParamsToQueryState = (urlParamsObj) => {
     const result = {};
+    let withSorting = false;
     Object.keys(urlParamsObj).forEach((paramKey) => {
       const queryStateKey = this.fromUrlParamsMapping[paramKey];
       if (this.urlParamValidator.isValid(this, queryStateKey, urlParamsObj[paramKey])) {
@@ -220,14 +224,15 @@ export class UrlHandlerApi {
           result[queryStateKey] = urlParamsObj[paramKey].map((filter) =>
             this._filterStringToList(filter)
           );
-        } else if (queryStateKey === 'sortBy') {
+        } else if (queryStateKey === 'sortBy' || queryStateKey === 'sortOrder') {
           // sorting was explicitly set in the url
-          result._sortUserChanged = true;
+          withSorting = true;
         }
       } else {
         console.warn(`URL parameter '${paramKey}' with value '${urlParamsObj[paramKey]}' is incorrect and was ignored.`);
       }
     });
+    result._userHasChangedSorting = withSorting;
     return result;
   };
 

--- a/src/lib/components/Sort/Sort.js
+++ b/src/lib/components/Sort/Sort.js
@@ -52,7 +52,6 @@ class Sort extends Component {
     return (
       <ShouldRender
         condition={
-          currentSortBy !== null &&
           (sortOrderDisabled || currentSortBy !== null) &&
           !loading &&
           totalResults > 0

--- a/src/lib/state/actions/query.js
+++ b/src/lib/state/actions/query.js
@@ -190,12 +190,7 @@ const updateQueryStateAfterResponse = (
     payload: response.newQueryState,
   });
 
-  const urlHandlerApi = appConfig.urlHandlerApi;
-  if (urlHandlerApi) {
-    // Replace the URL args with the response new query state
-    const updatedQueryState = _cloneDeep(getState().query);
-    urlHandlerApi.replace(updatedQueryState);
-  }
+  updateURLParameters(getState().query, appConfig, true, false);
   delete response.newStateQuery;
 };
 
@@ -205,8 +200,8 @@ const updateQueryStateSorting = (queryState, appState, appConfig) => {
     return newQueryState;
   }
 
-  const userHasChangedSorting = appState.hasUserChangedSorting || newQueryState._sortUserChanged;
-  if (!userHasChangedSorting) {
+  const _userHasChangedSorting = queryState._userHasChangedSorting;
+  if (!_userHasChangedSorting) {
     const isQueryStringEmpty = newQueryState.queryString === '';
     if (isQueryStringEmpty) {
       newQueryState.sortBy = appConfig.defaultSortingOnEmptyQueryString.sortBy;

--- a/src/lib/state/actions/query.test.js
+++ b/src/lib/state/actions/query.test.js
@@ -402,6 +402,7 @@ describe('test execute search sorting on empty query', () => {
     store.getState().query.queryString = 'text';
     store.getState().query.sortBy = 'mostpopular';
     store.getState().query.sortOrder = 'asc';
+    store.getState().query._userHasChangedSorting = true; // must be set explicitly
 
     await store.dispatch(
       executeQuery({

--- a/src/lib/state/reducers/app.js
+++ b/src/lib/state/reducers/app.js
@@ -6,29 +6,8 @@
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
-import {
-  SET_QUERY_SORTING,
-  SET_QUERY_SORT_BY,
-  SET_QUERY_SORT_ORDER,
-} from '../types';
-
 export default (state = {}, action) => {
   switch (action.type) {
-    case SET_QUERY_SORTING:
-      return {
-        ...state,
-        hasUserChangedSorting: true,
-      };
-    case SET_QUERY_SORT_BY:
-      return {
-        ...state,
-        hasUserChangedSorting: true,
-      };
-    case SET_QUERY_SORT_ORDER:
-      return {
-        ...state,
-        hasUserChangedSorting: true,
-      };
     default:
       return state;
   }

--- a/src/lib/state/reducers/query.js
+++ b/src/lib/state/reducers/query.js
@@ -34,21 +34,21 @@ export default (state = {}, action) => {
         ...state,
         sortBy: action.payload.sortBy,
         sortOrder: action.payload.sortOrder,
-        _sortUserChanged: true,
+        _userHasChangedSorting: true,
         page: 1,
       };
     case SET_QUERY_SORT_BY:
       return {
         ...state,
         sortBy: action.payload,
-        _sortUserChanged: true,
+        _userHasChangedSorting: true,
         page: 1,
       };
     case SET_QUERY_SORT_ORDER:
       return {
         ...state,
         sortOrder: action.payload,
-        _sortUserChanged: true,
+        _userHasChangedSorting: true,
         page: 1,
       };
     case SET_QUERY_PAGINATION_PAGE:

--- a/src/lib/storeConfig.js
+++ b/src/lib/storeConfig.js
@@ -16,6 +16,7 @@ export const INITIAL_QUERY_STATE = {
   filters: [],
   hiddenParams: [],
   layout: null,
+  _userHasChangedSorting: false,
 };
 
 export const INITIAL_QUERY_STATE_KEYS = Object.keys(INITIAL_QUERY_STATE);


### PR DESCRIPTION
* fixes the sorting filter not behaving properly since #149, namely the two following issues were resolved:
  * if the query is empty, then the sorting state was correctly set to `defaultSortingOnEmptyQueryString` but the url was not updated accordingly
  * if the page is reloaded, then the sorting parameters in the url were not used and the state would use the default value instead
* fixes a non-related programming mistake (the intent was assumed)

Tested on ILS, also made sure that it didn't break the history feature. Now:
* if the user did not change the sortby value *and* the url it came from did not contain a `sort` parameter, then:
  * the sortby value both in the state and in the url will depend on the query being empty or not, and will update accordingly so long as the user does not manually change the sortby value
* otherwise the sortby value will follow the user's choice