### PR TITLE
Disable change of sorting when defined in URL params

### DIFF
--- a/src/demos/App.js
+++ b/src/demos/App.js
@@ -8,16 +8,16 @@
 
 import React, { Component } from 'react';
 import {
-  Segment,
-  Menu,
-  Container,
-  Header,
   Button,
+  Container,
   Divider,
+  Header,
+  Menu,
+  Segment,
 } from 'semantic-ui-react';
+import { CERNVideosReactSearchKit } from './cern-videos';
 import { ESReactSearchKit } from './elasticsearch';
 import { ZenodoReactSearchKit } from './zenodo';
-import { CERNVideosReactSearchKit } from './cern-videos';
 
 const demos = {
   es7: {
@@ -49,7 +49,7 @@ export default class App extends Component {
 
   renderHeader = () => {
     const { activeDemo } = this.state;
-    const demoMenus = Object.keys(demos).map(key => (
+    const demoMenus = Object.keys(demos).map((key) => (
       <Menu.Item
         key={key}
         name={key}
@@ -83,7 +83,7 @@ export default class App extends Component {
   };
 
   renderContent = () => {
-    const links = Object.keys(demos).map(key => (
+    const links = Object.keys(demos).map((key) => (
       <Segment placeholder textAlign="center" key={key}>
         <Header>{demos[key].label}</Header>
         <p>{demos[key].text}</p>

--- a/src/lib/api/errors.js
+++ b/src/lib/api/errors.js
@@ -1,12 +1,15 @@
 /*
  * This file is part of React-SearchKit.
- * Copyright (C) 2018-2019 CERN.
+ * Copyright (C) 2020 CERN.
  *
  * React-SearchKit is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
-export * from './contrib';
-export * from './errors';
-export { UrlHandlerApi } from './UrlHandlerApi';
-export { UrlParamValidator } from './UrlParamValidator';
+/**
+ * Custom errors to raise specific expcetions
+ */
+
+export function RequestCancelledError() {}
+
+RequestCancelledError.prototype = new Error();

--- a/src/lib/state/reducers/results.js
+++ b/src/lib/state/reducers/results.js
@@ -1,23 +1,18 @@
 /*
  * This file is part of React-SearchKit.
- * Copyright (C) 2018-2019 CERN.
+ * Copyright (C) 2018-2020 CERN.
  *
  * React-SearchKit is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
 import {
-  RESULTS_LOADING,
-  RESULTS_FETCH_SUCCESS,
   RESULTS_FETCH_ERROR,
+  RESULTS_FETCH_SUCCESS,
+  RESULTS_LOADING,
 } from '../types';
 
 export default (state = {}, action) => {
-  // A completion event (success or error) should only update the state if it was
-  // originally triggered by the latest request made up to that point.
-  // Otherwise the result shall be ignored because there is a more recent request
-  // either waiting to complete, or that has already completed.
-  const isLatestRequest = action.payload && state.queryState === action.payload.queryState;
   switch (action.type) {
     case RESULTS_LOADING:
       return {
@@ -26,38 +21,29 @@ export default (state = {}, action) => {
         data: {
           ...state.data,
         },
-        queryState: action.payload.queryState,
       };
     case RESULTS_FETCH_SUCCESS:
-      if (isLatestRequest) {
-        return {
-          loading: false,
-          data: {
-            ...state.data,
-            aggregations: action.payload.aggregations,
-            hits: action.payload.hits,
-            total: action.payload.total,
-          },
-          error: {},
-        };
-      } else {
-        return state;
-      }
+      return {
+        loading: false,
+        data: {
+          ...state.data,
+          aggregations: action.payload.aggregations,
+          hits: action.payload.hits,
+          total: action.payload.total,
+        },
+        error: {},
+      };
     case RESULTS_FETCH_ERROR:
-      if (isLatestRequest) {
-        return {
-          loading: false,
-          data: {
-            ...state.data,
-            aggregations: {},
-            hits: [],
-            total: 0,
-          },
-          error: action.payload.error,
-        };
-      } else {
-        return state;
-      }
+      return {
+        loading: false,
+        data: {
+          ...state.data,
+          aggregations: {},
+          hits: [],
+          total: 0,
+        },
+        error: action.payload.error,
+      };
     default:
       return state;
   }


### PR DESCRIPTION
* when a specific sorting is defined in the URL params, the automatic
  change of sorting when query string is defined or empty will not have
  effect.
* changed the concurrency issue by replacing the query state in the
  results state check with the cancelling of previous axios requests