### PR TITLE
components: pass payload to resetQuery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+Version 1.0.0-alpha.13 (released 2021-02-10)
+
+- Use `config.initialQueryState` to override state when resetting query
+
 Version 1.0.0-alpha.12 (released 2021-02-04)
 
 * Added `size` option to Pagination component

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-searchkit",
-  "version": "1.0.0-alpha.12",
+  "version": "1.0.0-alpha.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-searchkit",
-  "version": "1.0.0-alpha.12",
+  "version": "1.0.0-alpha.13",
   "description": "React components to build your search UI application",
   "main": "dist/cjs/index.js",
   "browser": "dist/cjs/index.js",

--- a/src/lib/api/contrib/invenio/InvenioSearchApi.js
+++ b/src/lib/api/contrib/invenio/InvenioSearchApi.js
@@ -11,7 +11,7 @@ import _get from 'lodash/get';
 import _hasIn from 'lodash/hasIn';
 import _isEmpty from 'lodash/isEmpty';
 import { updateQueryState } from '../../../state/selectors';
-import { INITIAL_QUERY_STATE } from '../../../storeConfig';
+import { INITIAL_QUERY_STATE_KEYS } from '../../../storeConfig';
 import { RequestCancelledError } from '../../errors';
 import { InvenioRequestSerializer } from './InvenioRequestSerializer';
 import { InvenioResponseSerializer } from './InvenioResponseSerializer';
@@ -98,7 +98,7 @@ export class InvenioSearchApi {
       const newQueryState = updateQueryState(
         stateQuery,
         response.extras,
-        INITIAL_QUERY_STATE
+        INITIAL_QUERY_STATE_KEYS
       );
       if (!_isEmpty(newQueryState)) {
         response.newQueryState = newQueryState;

--- a/src/lib/state/actions/query.js
+++ b/src/lib/state/actions/query.js
@@ -142,9 +142,15 @@ export const updateResultsLayout = (layout) => {
 };
 
 export const resetQuery = () => {
-  return (dispatch) => {
+  return (dispatch, getState, config) => {
     dispatch({
       type: RESET_QUERY,
+      payload: {
+        queryString: '',
+        page: 1,
+        filters: [],
+        ...config.initialQueryState,
+      },
     });
     dispatch(executeQuery());
   };

--- a/src/lib/state/reducers/query.js
+++ b/src/lib/state/reducers/query.js
@@ -6,7 +6,11 @@
  * under the terms of the MIT License; see LICENSE file for more details.
  */
 
-import { INITIAL_QUERY_STATE, INITIAL_QUERY_STATE_KEYS } from '../../storeConfig';
+import _cloneDeep from 'lodash/cloneDeep';
+import {
+  INITIAL_QUERY_STATE,
+  INITIAL_QUERY_STATE_KEYS,
+} from '../../storeConfig';
 import { updateQueryFilters, updateQueryState } from '../selectors';
 import {
   CLEAR_QUERY_SUGGESTIONS,
@@ -93,7 +97,11 @@ export default (state = {}, action) => {
       return {
         ...state,
         ...INITIAL_QUERY_STATE,
-        ...updateQueryState(INITIAL_QUERY_STATE, action.payload, INITIAL_QUERY_STATE_KEYS),
+        ...updateQueryState(
+          INITIAL_QUERY_STATE,
+          action.payload,
+          INITIAL_QUERY_STATE_KEYS
+        ),
       };
     case RESULTS_UPDATE_LAYOUT:
       return {
@@ -103,9 +111,7 @@ export default (state = {}, action) => {
     case RESET_QUERY:
       return {
         ...state,
-        queryString: '',
-        page: 1,
-        filters: [],
+        ...action.payload,
       };
     default:
       return state;


### PR DESCRIPTION
closes inveniosoftware/invenio-app-rdm#531

When the action `resetQuery` is triggered there is no way to choose how to reset the query state. This PR gives the resetQuery action a payload that can be passed from components that override e.g the EmptyResults component. By doing that you can control the default query after the reset action is triggered!