### PR TITLE
components: fix SearchBar text missing on input

### DIFF
--- a/src/lib/components/SearchBar/SearchBar.js
+++ b/src/lib/components/SearchBar/SearchBar.js
@@ -103,8 +103,8 @@ SearchBar.defaultProps = {
 // NOTE: Adding the key prop, will recreate the SearchBar in order to update
 // state with the latest redux queryString value.
 // https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key
-const SearchBarUncontrolled = ({ queryString, ...props }) => (
-  <SearchBar key={queryString} {...props} />
+const SearchBarUncontrolled = ( props ) => (
+  <SearchBar key={props.queryString} {...props} />
 );
 
 SearchBarUncontrolled.propTypes = {


### PR DESCRIPTION
Fixed search bar's query text.

- Query text was cleared after the query being submitted. 

Note: the search bar component might not be fully uncontrolled. A new issue (https://github.com/inveniosoftware/react-searchkit/issues/225) was created for that matter, in order to perform a more thorough analysis.