### PR TITLE
fix the css-patch problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "@babel/runtime": "^7.9.0",
-    "@semantic-ui-react/css-patch": "^1.0.0",
+    "@semantic-ui-react/css-patch": "1.0.0",
     "axios": "^0.21.0",
     "lodash": "^4.17.0",
     "qs": "^6.8.0",
@@ -44,7 +44,7 @@
     "@rollup/plugin-babel": "^5.2.0",
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "@semantic-ui-react/css-patch": "^1.0.0",
+    "@semantic-ui-react/css-patch": "1.0.0",
     "axios": "^0.21.0",
     "axios-mock-adapter": "^1.18.0",
     "coveralls": "^3.0.0",


### PR DESCRIPTION
This PR fixes the following error message by pinning the version of `css-patch` `[0]` to 1.0.0. 

```
> react-searchkit@2.0.1 postinstall /opt/invenio/var/instance/assets/node_modules/react-searchkit
> semantic-ui-css-patch
ℹ No supported packages found
/opt/invenio/var/instance/assets/node_modules/@semantic-ui-react/css-patch/dist-node/index.bin.js:21
run(process.argv).catch(function (error) {
                 ^
TypeError: Cannot read property 'catch' of undefined
    at Object.<anonymous> (/opt/invenio/var/instance/assets/node_modules/@semantic-ui-react/css-patch/dist-node/index.bin.js:21:18)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
    at internal/main/run_main_module.js:17:47

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! react-searchkit@2.0.1 postinstall: `semantic-ui-css-patch`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the react-searchkit@2.0.1 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2022-08-03T15_31_22_236Z-debug.log
RuntimeError: Process exited with code 1
```

Only a guess but maybe it would fix the bug on css-path by adding a async to the run function. It was there before of the refactoring. But this seams out of scope and maybe it is not necessary for our purposes.

NOTE: i have no fast solution to test that locally. it should work, because there it worked with the version before, but if someone knows how to test something like that locally please let me know

`[0]`: https://www.npmjs.com/package/@semantic-ui-react/css-patch