### PR TITLE
bucket aggregations: render only if several buckets

### DIFF
--- a/src/lib/components/BucketAggregation/BucketAggregation.js
+++ b/src/lib/components/BucketAggregation/BucketAggregation.js
@@ -67,7 +67,7 @@ class BucketAggregation extends Component {
       this.props;
     const selectedFilters = this._getSelectedFilters(userSelectionFilters);
     const resultBuckets = this._getResultBuckets(resultsAggregations);
-    const valuesCmp = resultBuckets.length
+    const valuesCmp = resultBuckets.length > 1
       ? this._renderValues(resultBuckets, selectedFilters)
       : null;
     return (


### PR DESCRIPTION
* closes https://github.com/zenodo/rdm-project/issues/218

In case only 1 bucket is present, it doesn't make sense to show it.

Facets in case 2 types of visibility:
![Screenshot 2023-08-25 at 10 56 05](https://github.com/inveniosoftware/react-searchkit/assets/61321254/4a292e40-02df-48f9-b592-64281e997497)
![Screenshot 2023-08-25 at 10 58 25](https://github.com/inveniosoftware/react-searchkit/assets/61321254/db6d6f1b-7599-41c5-858e-fb3dae9a8c1b)


Facets in case only public visibility:
![Screenshot 2023-08-25 at 10 56 50](https://github.com/inveniosoftware/react-searchkit/assets/61321254/9f5cd738-551c-4d7b-b592-7e8e6397fea4)
![Screenshot 2023-08-25 at 10 58 58](https://github.com/inveniosoftware/react-searchkit/assets/61321254/53434029-23a8-4b59-8a72-a9ec410d0c0e)

