### PR TITLE
bucket aggregation: add id to checkbox

### DIFF
--- a/src/lib/components/BucketAggregation/BucketAggregationValues.js
+++ b/src/lib/components/BucketAggregation/BucketAggregationValues.js
@@ -152,6 +152,7 @@ const ValueElement = ({
       <List.Item key={bucket.key}>
         <Checkbox
           label={label}
+          id={`${bucket.key}-agg-value-checkbox`}
           value={bucket.key}
           onClick={() => onFilterClicked(bucket.key)}
           checked={isSelected}


### PR DESCRIPTION
Closes https://github.com/zenodo/zenodo-rdm/issues/458

- Adds id to `Checkbox` in `BucketAggregationValues` (needed for label to be related correctly)