### PR TITLE
InvenioSerializer: Remove parent category in nested filters

### DIFF
--- a/src/lib/api/contrib/invenio/InvenioRequestSerializer.js
+++ b/src/lib/api/contrib/invenio/InvenioRequestSerializer.js
@@ -25,16 +25,19 @@ export class InvenioRequestSerializer {
         `Filter value "${filter}" in query state must be an array of 2 or 3 elements`
       );
     }
-    const aggName = filter[0];
-    const fieldValue = filter[1];
+    const hasChild = filter.length === 3;
+    var aggName = filter[0];
+    var fieldValue = filter[1];
+    if (hasChild) {
+      if (!Array.isArray(filter[2])) {
+        throw new Error(`Filter value "${filter[2]}" in query state must be an array.`);
+      }
+      fieldValue = fieldValue + "::" + filter[2][1];
+    }
     if (aggName in filterUrlParams) {
       filterUrlParams[aggName].push(fieldValue);
     } else {
       filterUrlParams[aggName] = [fieldValue];
-    }
-    const hasChild = filter.length === 3;
-    if (hasChild) {
-      this._addFilter(filter[2], filterUrlParams);
     }
   };
 
@@ -54,8 +57,7 @@ export class InvenioRequestSerializer {
     });
     /**
      * output: {
-     *  type_agg: 'value1'.
-     *  subtype_agg: 'a value'
+     *  type_agg: [ 'value1', 'value2::a value' ]
      * }
      */
     return filterUrlParams;

--- a/src/lib/api/contrib/invenio/InvenioRequestSerializer.test.js
+++ b/src/lib/api/contrib/invenio/InvenioRequestSerializer.test.js
@@ -120,7 +120,24 @@ describe("test InvenioRequestSerializer serializer", () => {
       ],
     };
     const strState = serializer.serialize(queryState);
-    expect(strState).toBe("q=test&type=report&subtype=pdf&category=video");
+    expect(strState).toBe("q=test&type=report%3A%3Apdf&category=video");
+  });
+
+  it("should serialize multiple nested filters", () => {
+    const queryState = {
+      queryString: "test",
+      page: 0,
+      size: 0,
+      filters: [
+        ["type", "report", ["subtype", "pdf"]],
+        ["type", "report", ["subtype", "doc"]],
+        ["category", "video"],
+      ],
+    };
+    const strState = serializer.serialize(queryState);
+    expect(strState).toBe(
+      "q=test&type=report%3A%3Apdf&type=report%3A%3Adoc&category=video"
+    );
   });
 
   it("should fail when filters have wrong format", () => {


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

The nested facets are not working properly. A request like `f=type%3ADataset&f=type%3ADocumentation%2Bsubtype%3AAbout` gets translated into `type=Dataset&type=Documentation&subtype=About`, instead of `type=Dataset&subtype=About`.

Note that the comments in the code (line 45-60) were correct. The implementation was different :-)

