### PR TITLE
results grid: pass correct value to results prop

### DIFF
--- a/src/lib/components/ResultsGrid/ResultsGrid.js
+++ b/src/lib/components/ResultsGrid/ResultsGrid.js
@@ -71,7 +71,7 @@ const Element = ({ overridableId, results, resultsPerRow }) => {
   return (
     <Overridable
       id={buildUID("ResultsGrid.container", overridableId)}
-      results={results}
+      results={_results}
       resultsPerRow={resultsPerRow}
     >
       <Card.Group itemsPerRow={resultsPerRow}>{_results}</Card.Group>


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/567

- I believe this was a bug, as it is passed in the same way for `ResultsList`, and also makes it easier to override this way. 