### PR TITLE
allow for Pagination and ResultsPerPage to be hidden on few results

### DIFF
--- a/docs/docs/components/pagination.md
+++ b/docs/docs/components/pagination.md
@@ -67,3 +67,9 @@ const overriddenComponents = {
 * **options** `object`
 
   The options prop passed to the component.
+
+* **showWhenOnlyOnePage** `Boolean`
+
+  Allows to configure whether or not the component will render when there is only one page of results available. Default value: `true`.
+
+  

--- a/docs/docs/components/results_per_page.md
+++ b/docs/docs/components/results_per_page.md
@@ -63,3 +63,7 @@ const overriddenComponents = {
 * **selectOnNavigation** `Boolean`
 
   When using a dropdown, set if the `onValueChange` should be called when the new dropdown item is selected with arrow keys, or only on click or on enter.
+
+* **showWhenOnlyOnePage** `Boolean`
+
+  Allows to configure whether or not the component will render when there is only one page of results available. Default value: `true`.

--- a/src/lib/components/Pagination/Pagination.js
+++ b/src/lib/components/Pagination/Pagination.js
@@ -46,14 +46,14 @@ class Pagination extends Component {
       currentPage,
       currentSize,
       overridableId,
-      renderBasedOnCurrentSize,
+      showWhenOnlyOnePage,
     } = this.props;
     return (
       <ShouldRender
         condition={
-          !loading && currentPage > -1 && currentSize > -1 && renderBasedOnCurrentSize
-            ? totalResults > currentSize
-            : totalResults > 0
+          !loading && currentPage > -1 && currentSize > -1 && showWhenOnlyOnePage
+            ? totalResults > 0
+            : totalResults > currentSize
         }
       >
         <Element
@@ -83,7 +83,7 @@ Pagination.propTypes = {
     maxTotalResults: PropTypes.number,
   }),
   overridableId: PropTypes.string,
-  renderBasedOnCurrentSize: PropTypes.bool,
+  showWhenOnlyOnePage: PropTypes.bool,
   /* REDUX */
   currentPage: PropTypes.number.isRequired,
   currentSize: PropTypes.number.isRequired,
@@ -95,7 +95,7 @@ Pagination.propTypes = {
 Pagination.defaultProps = {
   options: {},
   overridableId: "",
-  renderBasedOnCurrentSize: false,
+  showWhenOnlyOnePage: true,
 };
 
 const Element = ({

--- a/src/lib/components/Pagination/Pagination.js
+++ b/src/lib/components/Pagination/Pagination.js
@@ -40,11 +40,21 @@ class Pagination extends Component {
   };
 
   render() {
-    const { loading, totalResults, currentPage, currentSize, overridableId } =
-      this.props;
+    const {
+      loading,
+      totalResults,
+      currentPage,
+      currentSize,
+      overridableId,
+      renderBasedOnCurrentSize,
+    } = this.props;
     return (
       <ShouldRender
-        condition={!loading && currentPage > -1 && currentSize > -1 && totalResults > 0}
+        condition={
+          !loading && currentPage > -1 && currentSize > -1 && renderBasedOnCurrentSize
+            ? totalResults > currentSize
+            : totalResults > 0
+        }
       >
         <Element
           currentPage={currentPage}
@@ -73,6 +83,7 @@ Pagination.propTypes = {
     maxTotalResults: PropTypes.number,
   }),
   overridableId: PropTypes.string,
+  renderBasedOnCurrentSize: PropTypes.bool,
   /* REDUX */
   currentPage: PropTypes.number.isRequired,
   currentSize: PropTypes.number.isRequired,
@@ -84,6 +95,7 @@ Pagination.propTypes = {
 Pagination.defaultProps = {
   options: {},
   overridableId: "",
+  renderBasedOnCurrentSize: false,
 };
 
 const Element = ({

--- a/src/lib/components/ResultsPerPage/ResultsPerPage.js
+++ b/src/lib/components/ResultsPerPage/ResultsPerPage.js
@@ -36,9 +36,16 @@ class ResultsPerPage extends Component {
       overridableId,
       ariaLabel,
       selectOnNavigation,
+      renderBasedOnCurrentSize,
     } = this.props;
     return (
-      <ShouldRender condition={!loading && totalResults > 0 && currentSize !== -1}>
+      <ShouldRender
+        condition={
+          !loading && currentSize !== -1 && renderBasedOnCurrentSize
+            ? totalResults > currentSize
+            : totalResults > 0
+        }
+      >
         {label(
           <Element
             currentSize={currentSize}
@@ -60,6 +67,7 @@ ResultsPerPage.propTypes = {
   overridableId: PropTypes.string,
   ariaLabel: PropTypes.string,
   selectOnNavigation: PropTypes.bool,
+  renderBasedOnCurrentSize: PropTypes.bool,
   /* REDUX */
   currentSize: PropTypes.number.isRequired,
   loading: PropTypes.bool.isRequired,
@@ -72,6 +80,7 @@ ResultsPerPage.defaultProps = {
   overridableId: "",
   ariaLabel: "Results per page",
   selectOnNavigation: false,
+  renderBasedOnCurrentSize: false,
 };
 
 const Element = ({

--- a/src/lib/components/ResultsPerPage/ResultsPerPage.js
+++ b/src/lib/components/ResultsPerPage/ResultsPerPage.js
@@ -36,14 +36,14 @@ class ResultsPerPage extends Component {
       overridableId,
       ariaLabel,
       selectOnNavigation,
-      renderBasedOnCurrentSize,
+      showWhenOnlyOnePage,
     } = this.props;
     return (
       <ShouldRender
         condition={
-          !loading && currentSize !== -1 && renderBasedOnCurrentSize
-            ? totalResults > currentSize
-            : totalResults > 0
+          !loading && currentSize !== -1 && showWhenOnlyOnePage
+            ? totalResults > 0
+            : totalResults > currentSize
         }
       >
         {label(
@@ -67,7 +67,7 @@ ResultsPerPage.propTypes = {
   overridableId: PropTypes.string,
   ariaLabel: PropTypes.string,
   selectOnNavigation: PropTypes.bool,
-  renderBasedOnCurrentSize: PropTypes.bool,
+  showWhenOnlyOnePage: PropTypes.bool,
   /* REDUX */
   currentSize: PropTypes.number.isRequired,
   loading: PropTypes.bool.isRequired,
@@ -80,7 +80,7 @@ ResultsPerPage.defaultProps = {
   overridableId: "",
   ariaLabel: "Results per page",
   selectOnNavigation: false,
-  renderBasedOnCurrentSize: false,
+  showWhenOnlyOnePage: true,
 };
 
 const Element = ({


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

Added a prop that allows to program Pagination and ResultsPerPage components to not render in certain conditions (when there are less results than resultsPerPage setting). If unused the components behave same as before.

