### PR TITLE
pagination: fix negative page numbers on empty query

### DIFF
--- a/src/lib/components/Pagination/Pagination.js
+++ b/src/lib/components/Pagination/Pagination.js
@@ -1,6 +1,7 @@
 /*
  * This file is part of React-SearchKit.
  * Copyright (C) 2018-2022 CERN.
+ * Copyright (C) 2024      KTH Royal Institute of Technology.
  *
  * React-SearchKit is free software; you can redistribute it and/or modify it
  * under the terms of the MIT License; see LICENSE file for more details.
@@ -48,6 +49,10 @@ class Pagination extends Component {
       overridableId,
       showWhenOnlyOnePage,
     } = this.props;
+
+    const validCurrentPage = currentPage > 0 ? currentPage : 1;
+    const validCurrentSize = currentSize > 0 ? currentSize : 25;
+
     return (
       <ShouldRender
         condition={
@@ -57,8 +62,8 @@ class Pagination extends Component {
         }
       >
         <Element
-          currentPage={currentPage}
-          currentSize={currentSize}
+          currentPage={validCurrentPage}
+          currentSize={validCurrentSize}
           totalResults={totalResults}
           onPageChange={this.onPageChange}
           options={this.options}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* closes https://github.com/inveniosoftware/invenio-communities/issues/1136

the original symptom is that the [initial value in the Redux store starts at -1](https://github.com/inveniosoftware/react-searchkit/blob/master/src/lib/storeConfig.js#L14-L15). Changing it resolves the problem, but I am concerned that other logic might rely on the init value, potentially causing other issues. Therefore, I limited my change to this component.

## Before:
[Screencast from 2024-05-28 16:07:46.webm](https://github.com/inveniosoftware/invenio-communities/assets/36583694/63a547bf-567e-4b85-97cf-5dbcf8262f65)

## After

![test-pagination-4](https://github.com/inveniosoftware/invenio-communities/assets/36583694/fba341e7-14d2-4524-88ca-f8c9ef692862)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
