### PR TITLE
components: remove defaultProps from components

### DIFF
--- a/src/lib/components/ActiveFilters/ActiveFilters.js
+++ b/src/lib/components/ActiveFilters/ActiveFilters.js
@@ -60,7 +60,12 @@ ActiveFilters.defaultProps = {
   overridableId: "",
 };
 
-const Element = ({ overridableId, filters, removeActiveFilter, getLabel }) => {
+const Element = ({
+  overridableId = "",
+  filters,
+  removeActiveFilter,
+  getLabel,
+}) => {
   const { buildUID } = useContext(AppContext);
 
   return (
@@ -91,10 +96,6 @@ Element.propTypes = {
   removeActiveFilter: PropTypes.func.isRequired,
   getLabel: PropTypes.func.isRequired,
   overridableId: PropTypes.string,
-};
-
-Element.defaultProps = {
-  overridableId: "",
 };
 
 export default Overridable.component("ActiveFilters", ActiveFilters);

--- a/src/lib/components/BucketAggregation/BucketAggregation.js
+++ b/src/lib/components/BucketAggregation/BucketAggregation.js
@@ -99,7 +99,13 @@ BucketAggregation.defaultProps = {
   overridableId: "",
 };
 
-const Element = ({ overridableId, agg, title, containerCmp, updateQueryFilters }) => {
+const Element = ({
+  overridableId = "",
+  agg,
+  title,
+  containerCmp = null,
+  updateQueryFilters,
+}) => {
   const { buildUID } = useContext(AppContext);
 
   return (
@@ -128,11 +134,6 @@ Element.propTypes = {
   containerCmp: PropTypes.node,
   overridableId: PropTypes.string,
   updateQueryFilters: PropTypes.func.isRequired,
-};
-
-Element.defaultProps = {
-  containerCmp: null,
-  overridableId: "",
 };
 
 export default Overridable.component("BucketAggregation", BucketAggregation);

--- a/src/lib/components/BucketAggregation/BucketAggregationValues.js
+++ b/src/lib/components/BucketAggregation/BucketAggregationValues.js
@@ -104,7 +104,7 @@ BucketAggregationValues.defaultProps = {
   overridableId: "",
 };
 
-const ContainerElement = ({ valuesCmp, overridableId }) => {
+const ContainerElement = ({ valuesCmp, overridableId = "" }) => {
   const { buildUID } = useContext(AppContext);
 
   return (
@@ -122,16 +122,12 @@ ContainerElement.propTypes = {
   overridableId: PropTypes.string,
 };
 
-ContainerElement.defaultProps = {
-  overridableId: "",
-};
-
 const ValueElement = ({
   bucket,
   isSelected,
   onFilterClicked,
   getChildAggCmps,
-  overridableId,
+  overridableId = "",
   keyField,
 }) => {
   const { buildUID, nextComponentIndex } = useContext(AppContext);
@@ -172,10 +168,6 @@ ValueElement.propTypes = {
   getChildAggCmps: PropTypes.func.isRequired,
   keyField: PropTypes.string.isRequired,
   overridableId: PropTypes.string,
-};
-
-ValueElement.defaultProps = {
-  overridableId: "",
 };
 
 export default Overridable.component(

--- a/src/lib/components/Count/Count.js
+++ b/src/lib/components/Count/Count.js
@@ -15,7 +15,7 @@ import { ShouldRender } from "../ShouldRender";
 
 class Count extends Component {
   render() {
-    const { loading, totalResults, label, overridableId } = this.props;
+    const { loading, totalResults, label = (cmp) => cmp, overridableId = "" } = this.props;
     return (
       <ShouldRender condition={!loading && totalResults > 0}>
         {label(<Element totalResults={totalResults} overridableId={overridableId} />)}
@@ -32,12 +32,7 @@ Count.propTypes = {
   totalResults: PropTypes.number.isRequired,
 };
 
-Count.defaultProps = {
-  label: (cmp) => cmp,
-  overridableId: "",
-};
-
-const Element = ({ totalResults, overridableId }) => {
+const Element = ({ totalResults, overridableId = "" }) => {
   const { buildUID } = useContext(AppContext);
   const _overridableId = buildUID("Count.element", overridableId);
 
@@ -51,10 +46,6 @@ const Element = ({ totalResults, overridableId }) => {
 Element.propTypes = {
   totalResults: PropTypes.number.isRequired,
   overridableId: PropTypes.string,
-};
-
-Element.defaultProps = {
-  overridableId: "",
 };
 
 export default Overridable.component("Count", Count);

--- a/src/lib/components/EmptyResults/EmptyResults.js
+++ b/src/lib/components/EmptyResults/EmptyResults.js
@@ -65,10 +65,10 @@ EmptyResults.defaultProps = {
 };
 
 const Element = ({
-  overridableId,
-  queryString,
+  overridableId = "",
+  queryString = "",
   resetQuery,
-  extraContent,
+  extraContent = null,
   userSelectionFilters,
 }) => {
   const { buildUID } = useContext(AppContext);
@@ -103,12 +103,6 @@ Element.propTypes = {
   extraContent: PropTypes.node,
   overridableId: PropTypes.string,
   userSelectionFilters: PropTypes.array.isRequired,
-};
-
-Element.defaultProps = {
-  queryString: "",
-  extraContent: null,
-  overridableId: "",
 };
 
 export default Overridable.component("EmptyResults", EmptyResults);

--- a/src/lib/components/Error/Error.js
+++ b/src/lib/components/Error/Error.js
@@ -13,7 +13,7 @@ import Overridable from "react-overridable";
 import { AppContext } from "../ReactSearchKit";
 import { ShouldRender } from "../ShouldRender";
 
-function Error({ loading, error, overridableId }) {
+function Error({ loading, error, overridableId = "" }) {
   return (
     <ShouldRender condition={!loading && !_isEmpty(error)}>
       <Element error={error} overridableId={overridableId} />
@@ -28,11 +28,7 @@ Error.propTypes = {
   error: PropTypes.object.isRequired,
 };
 
-Error.defaultProps = {
-  overridableId: "",
-};
-
-const Element = ({ error, overridableId }) => {
+const Element = ({ error, overridableId = "" }) => {
   const { buildUID } = useContext(AppContext);
 
   return (
@@ -46,10 +42,6 @@ Element.propTypes = {
   overridableId: PropTypes.string,
   /* REDUX */
   error: PropTypes.object.isRequired,
-};
-
-Element.defaultProps = {
-  overridableId: "",
 };
 
 export default Overridable.component("Error", Error);

--- a/src/lib/components/LayoutSwitcher/LayoutSwitcher.js
+++ b/src/lib/components/LayoutSwitcher/LayoutSwitcher.js
@@ -24,7 +24,12 @@ class LayoutSwitcher extends Component {
   };
 
   render() {
-    const { currentLayout, loading, totalResults, overridableId } = this.props;
+    const {
+      currentLayout = null,
+      loading,
+      totalResults,
+      overridableId = "",
+    } = this.props;
     return (
       <ShouldRender condition={currentLayout !== null && !loading && totalResults > 0}>
         <Element
@@ -46,12 +51,11 @@ LayoutSwitcher.propTypes = {
   totalResults: PropTypes.number.isRequired,
 };
 
-LayoutSwitcher.defaultProps = {
-  currentLayout: null,
-  overridableId: "",
-};
-
-const Element = ({ overridableId, currentLayout, onLayoutChange }) => {
+const Element = ({
+  overridableId = "",
+  currentLayout = null,
+  onLayoutChange,
+}) => {
   const { buildUID } = useContext(AppContext);
   return (
     <Overridable
@@ -83,11 +87,6 @@ Element.propTypes = {
   currentLayout: PropTypes.string,
   onLayoutChange: PropTypes.func.isRequired,
   overridableId: PropTypes.string,
-};
-
-Element.defaultProps = {
-  currentLayout: null,
-  overridableId: "",
 };
 
 export default Overridable.component("LayoutSwitcher", LayoutSwitcher);

--- a/src/lib/components/Pagination/Pagination.js
+++ b/src/lib/components/Pagination/Pagination.js
@@ -99,13 +99,13 @@ Pagination.defaultProps = {
 };
 
 const Element = ({
-  overridableId,
+  overridableId = "",
   currentPage,
   currentSize,
   totalResults,
   onPageChange,
-  options,
-  maxTotalResults,
+  options = {},
+  maxTotalResults = 10000,
   ...props
 }) => {
   const boundaryRangeCount = options.boundaryRangeCount;
@@ -159,12 +159,6 @@ Element.propTypes = {
   options: PropTypes.object,
   overridableId: PropTypes.string,
   maxTotalResults: PropTypes.number,
-};
-
-Element.defaultProps = {
-  options: {},
-  overridableId: "",
-  maxTotalResults: 10000,
 };
 
 export default Overridable.component("Pagination", Pagination);

--- a/src/lib/components/RangeFacet/RangeDefaultFilters.js
+++ b/src/lib/components/RangeFacet/RangeDefaultFilters.js
@@ -111,9 +111,9 @@ RangeDefaultFilters.defaultProps = {
 
 const RangeDefaultFiltersElement = ({
   ranges,
-  activeLabel,
+  activeLabel = null,
   onToggle,
-  overridableId,
+  overridableId = "",
 }) => {
   const { buildUID } = useContext(AppContext);
 
@@ -150,9 +150,7 @@ RangeDefaultFiltersElement.propTypes = {
   overridableId: PropTypes.string,
 };
 
-RangeDefaultFiltersElement.defaultProps = {
-  activeLabel: null,
-  overridableId: "",
-};
-
-export default Overridable.component("RangeFacet.DefaultFilters", RangeDefaultFilters);
+export default Overridable.component(
+  "RangeFacet.DefaultFilters",
+  RangeDefaultFilters
+);

--- a/src/lib/components/RangeFacet/RangeFacet.js
+++ b/src/lib/components/RangeFacet/RangeFacet.js
@@ -355,10 +355,10 @@ export default Overridable.component("RangeFacet", withState(RangeFacet));
 
 const RangeFacetElement = ({
   title,
-  containerCmp,
+  containerCmp = null,
   hasActiveFilter,
   onClear,
-  overridableId,
+  overridableId = "",
 }) => {
   const { buildUID } = React.useContext(AppContext);
 
@@ -388,9 +388,4 @@ RangeFacetElement.propTypes = {
   hasActiveFilter: PropTypes.bool.isRequired,
   onClear: PropTypes.func.isRequired,
   overridableId: PropTypes.string,
-};
-
-RangeFacetElement.defaultProps = {
-  containerCmp: null,
-  overridableId: "",
 };

--- a/src/lib/components/RangeFacet/RangeHistogram.js
+++ b/src/lib/components/RangeFacet/RangeHistogram.js
@@ -111,12 +111,12 @@ const RangeHistogramElement = ({
   height,
   xScale,
   yScale,
-  hoveredYear,
-  tooltip,
+  hoveredYear = null,
+  tooltip = null,
   onBarClick,
   onBarHover,
   onBarLeave,
-  overridableId,
+  overridableId = "",
 }) => {
   const { buildUID } = useContext(AppContext);
 
@@ -179,13 +179,7 @@ RangeHistogramElement.propTypes = {
   overridableId: PropTypes.string,
 };
 
-RangeHistogramElement.defaultProps = {
-  hoveredYear: null,
-  tooltip: null,
-  overridableId: "",
-};
-
-const RangeHistogramTooltip = ({ tooltip, overridableId }) => {
+const RangeHistogramTooltip = ({ tooltip = null, overridableId = "" }) => {
   const { buildUID } = useContext(AppContext);
 
   return (
@@ -225,9 +219,7 @@ RangeHistogramTooltip.propTypes = {
   overridableId: PropTypes.string,
 };
 
-RangeHistogramTooltip.defaultProps = {
-  tooltip: null,
-  overridableId: "",
-};
-
-export default Overridable.component("RangeHistogram", withParentSize(RangeHistogram));
+export default Overridable.component(
+  "RangeHistogram",
+  withParentSize(RangeHistogram)
+);

--- a/src/lib/components/ResultsGrid/ResultsGrid.js
+++ b/src/lib/components/ResultsGrid/ResultsGrid.js
@@ -17,9 +17,9 @@ function ResultsGrid({
   loading,
   totalResults,
   results,
-  resultsPerRow,
-  overridableId,
-  onResultsRendered,
+  resultsPerRow = 3,
+  overridableId = "",
+  onResultsRendered = () => {},
 }) {
   useEffect(() => {
     if (onResultsRendered) {
@@ -48,12 +48,6 @@ ResultsGrid.propTypes = {
   results: PropTypes.array.isRequired,
 };
 
-ResultsGrid.defaultProps = {
-  resultsPerRow: 3,
-  overridableId: "",
-  onResultsRendered: () => {},
-};
-
 const GridItem = ({ result, overridableId }) => {
   const { buildUID } = useContext(AppContext);
 
@@ -75,7 +69,7 @@ GridItem.propTypes = {
   overridableId: PropTypes.string.isRequired,
 };
 
-const Element = ({ overridableId, results, resultsPerRow }) => {
+const Element = ({ overridableId = "", results, resultsPerRow = 3 }) => {
   const { buildUID } = useContext(AppContext);
 
   const _results = results.map((result, index) => (
@@ -98,11 +92,6 @@ Element.propTypes = {
   results: PropTypes.array.isRequired,
   resultsPerRow: PropTypes.number,
   overridableId: PropTypes.string,
-};
-
-Element.defaultProps = {
-  resultsPerRow: 3,
-  overridableId: "",
 };
 
 export default Overridable.component("ResultsGrid", ResultsGrid);

--- a/src/lib/components/ResultsList/ResultsList.js
+++ b/src/lib/components/ResultsList/ResultsList.js
@@ -17,8 +17,8 @@ function ResultsList({
   loading,
   totalResults,
   results,
-  overridableId,
-  onResultsRendered,
+  overridableId = "",
+  onResultsRendered = () => {},
 }) {
   useEffect(() => {
     if (onResultsRendered) {
@@ -42,11 +42,6 @@ ResultsList.propTypes = {
   results: PropTypes.array.isRequired,
 };
 
-ResultsList.defaultProps = {
-  overridableId: "",
-  onResultsRendered: () => {},
-};
-
 const ListItem = ({ result, overridableId }) => {
   const { buildUID } = useContext(AppContext);
 
@@ -68,7 +63,7 @@ ListItem.propTypes = {
   overridableId: PropTypes.string.isRequired,
 };
 
-const Element = ({ results, overridableId }) => {
+const Element = ({ results, overridableId = "" }) => {
   const { buildUID } = useContext(AppContext);
 
   const _results = results.map((result, index) => (
@@ -91,10 +86,6 @@ const Element = ({ results, overridableId }) => {
 Element.propTypes = {
   results: PropTypes.array.isRequired,
   overridableId: PropTypes.string,
-};
-
-Element.defaultProps = {
-  overridableId: "",
 };
 
 export default Overridable.component("ResultsList", ResultsList);

--- a/src/lib/components/ResultsLoader/ResultsLoader.js
+++ b/src/lib/components/ResultsLoader/ResultsLoader.js
@@ -12,7 +12,7 @@ import Overridable from "react-overridable";
 import { Loader } from "semantic-ui-react";
 import { AppContext } from "../ReactSearchKit";
 
-function ResultsLoader({ children, loading, overridableId }) {
+function ResultsLoader({ children, loading, overridableId = "" }) {
   return loading ? <Element overridableId={overridableId} /> : children;
 }
 
@@ -23,11 +23,7 @@ ResultsLoader.propTypes = {
   loading: PropTypes.bool.isRequired,
 };
 
-ResultsLoader.defaultProps = {
-  overridableId: "",
-};
-
-const Element = ({ overridableId }) => {
+const Element = ({ overridableId = "" }) => {
   const { buildUID } = useContext(AppContext);
 
   return (
@@ -39,10 +35,6 @@ const Element = ({ overridableId }) => {
 
 Element.propTypes = {
   overridableId: PropTypes.string,
-};
-
-Element.defaultProps = {
-  overridableId: "",
 };
 
 export default Overridable.component("ResultsLoader", ResultsLoader);

--- a/src/lib/components/ResultsMultiLayout/ResultsMultiLayout.js
+++ b/src/lib/components/ResultsMultiLayout/ResultsMultiLayout.js
@@ -17,9 +17,9 @@ import { ShouldRender } from "../ShouldRender";
 function ResultsMultiLayout({
   loading,
   totalResults,
-  currentLayout,
-  overridableId,
-  onResultsRendered,
+  currentLayout = null,
+  overridableId = "",
+  onResultsRendered = () => {},
 }) {
   return (
     <ShouldRender condition={currentLayout != null && !loading && totalResults > 0}>
@@ -41,13 +41,11 @@ ResultsMultiLayout.propTypes = {
   totalResults: PropTypes.number.isRequired,
 };
 
-ResultsMultiLayout.defaultProps = {
-  currentLayout: null,
-  overridableId: "",
-  onResultsRendered: () => {},
-};
-
-const Element = ({ layout, overridableId, onResultsRendered }) => {
+const Element = ({
+  layout = "",
+  overridableId = "",
+  onResultsRendered = () => {},
+}) => {
   const { buildUID } = useContext(AppContext);
   return (
     <Overridable
@@ -74,12 +72,6 @@ Element.propTypes = {
   layout: PropTypes.string,
   overridableId: PropTypes.string,
   onResultsRendered: PropTypes.func,
-};
-
-Element.defaultProps = {
-  layout: "",
-  overridableId: "",
-  onResultsRendered: () => {},
 };
 
 export default Overridable.component("ResultsMultiLayout", ResultsMultiLayout);

--- a/src/lib/components/ResultsPerPage/ResultsPerPage.js
+++ b/src/lib/components/ResultsPerPage/ResultsPerPage.js
@@ -32,11 +32,11 @@ class ResultsPerPage extends Component {
       loading,
       currentSize,
       totalResults,
-      label,
-      overridableId,
-      ariaLabel,
-      selectOnNavigation,
-      showWhenOnlyOnePage,
+      label = (cmp) => cmp,
+      overridableId = "",
+      ariaLabel = "Results per page",
+      selectOnNavigation = false,
+      showWhenOnlyOnePage = true,
     } = this.props;
     return (
       <ShouldRender
@@ -75,21 +75,13 @@ ResultsPerPage.propTypes = {
   updateQuerySize: PropTypes.func.isRequired,
 };
 
-ResultsPerPage.defaultProps = {
-  label: (cmp) => cmp,
-  overridableId: "",
-  ariaLabel: "Results per page",
-  selectOnNavigation: false,
-  showWhenOnlyOnePage: true,
-};
-
 const Element = ({
-  overridableId,
+  overridableId = "",
   currentSize,
   options,
   onValueChange,
-  ariaLabel,
-  selectOnNavigation,
+  ariaLabel = "Results per page",
+  selectOnNavigation = false,
 }) => {
   const { buildUID } = useContext(AppContext);
   const _options = options.map((element, index) => {
@@ -125,12 +117,6 @@ Element.propTypes = {
   selectOnNavigation: PropTypes.bool,
   onValueChange: PropTypes.func.isRequired,
   overridableId: PropTypes.string,
-};
-
-Element.defaultProps = {
-  ariaLabel: "Results per page",
-  selectOnNavigation: false,
-  overridableId: "",
 };
 
 export default Overridable.component("ResultsPerPage", ResultsPerPage);

--- a/src/lib/components/SearchBar/SearchBar.js
+++ b/src/lib/components/SearchBar/SearchBar.js
@@ -103,17 +103,12 @@ SearchBar.defaultProps = {
 // NOTE: Adding the key prop, will recreate the SearchBar in order to update
 // state with the latest redux queryString value.
 // https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key
-const SearchBarUncontrolled = (props) => {
-  const { queryString } = props;
-  return <SearchBar key={queryString} {...props} />;
+const SearchBarUncontrolled = ({ queryString = "", ...rest }) => {
+  return <SearchBar key={queryString} queryString={queryString} {...rest} />;
 };
 
 SearchBarUncontrolled.propTypes = {
   queryString: PropTypes.string,
-};
-
-SearchBarUncontrolled.defaultProps = {
-  queryString: "",
 };
 
 class Element extends Component {

--- a/src/lib/components/ShouldRender/ShouldRender.js
+++ b/src/lib/components/ShouldRender/ShouldRender.js
@@ -12,7 +12,7 @@ import Overridable from "react-overridable";
 
 class ShouldRender extends Component {
   render() {
-    const { children, condition } = this.props;
+    const { children, condition = true } = this.props;
     return condition ? children : null;
   }
 }
@@ -20,10 +20,6 @@ class ShouldRender extends Component {
 ShouldRender.propTypes = {
   condition: PropTypes.bool,
   children: PropTypes.node.isRequired,
-};
-
-ShouldRender.defaultProps = {
-  condition: true,
 };
 
 export default Overridable.component("ShouldRender", ShouldRender);

--- a/src/lib/components/Sort/Sort.js
+++ b/src/lib/components/Sort/Sort.js
@@ -101,14 +101,14 @@ Sort.defaultProps = {
 };
 
 const Element = ({
-  overridableId,
-  currentSortBy,
-  currentSortOrder,
+  overridableId = "",
+  currentSortBy = null,
+  currentSortOrder = null,
   options,
   onValueChange,
   computeValue,
-  ariaLabel,
-  selectOnNavigation,
+  ariaLabel = "Sort",
+  selectOnNavigation = false,
 }) => {
   const { buildUID } = useContext(AppContext);
   const selected = computeValue(currentSortBy, currentSortOrder);
@@ -150,14 +150,6 @@ Element.propTypes = {
   selectOnNavigation: PropTypes.bool,
   computeValue: PropTypes.func.isRequired,
   onValueChange: PropTypes.func.isRequired,
-};
-
-Element.defaultProps = {
-  currentSortBy: null,
-  currentSortOrder: null,
-  overridableId: "",
-  ariaLabel: "Sort",
-  selectOnNavigation: false,
 };
 
 export default Overridable.component("Sort", Sort);

--- a/src/lib/components/SortBy/SortBy.js
+++ b/src/lib/components/SortBy/SortBy.js
@@ -76,12 +76,12 @@ SortBy.defaultProps = {
 };
 
 const Element = ({
-  overridableId,
-  currentSortBy,
+  overridableId = "",
+  currentSortBy = null,
   options,
   onValueChange,
-  ariaLabel,
-  selectOnNavigation,
+  ariaLabel = "Sort Results By",
+  selectOnNavigation = false,
 }) => {
   const { buildUID } = useContext(AppContext);
 
@@ -118,13 +118,6 @@ Element.propTypes = {
   ariaLabel: PropTypes.string,
   selectOnNavigation: PropTypes.bool,
   onValueChange: PropTypes.func.isRequired,
-};
-
-Element.defaultProps = {
-  currentSortBy: null,
-  overridableId: "",
-  ariaLabel: "Sort Results By",
-  selectOnNavigation: false,
 };
 
 export default Overridable.component("SortBy", SortBy);

--- a/src/lib/components/SortOrder/SortOrder.js
+++ b/src/lib/components/SortOrder/SortOrder.js
@@ -78,12 +78,12 @@ SortOrder.defaultProps = {
 };
 
 const Element = ({
-  overridableId,
-  currentSortOrder,
+  overridableId = "",
+  currentSortOrder = null,
   options,
   onValueChange,
-  ariaLabel,
-  selectOnNavigation,
+  ariaLabel = "Sort Order",
+  selectOnNavigation = false,
 }) => {
   const { buildUID } = useContext(AppContext);
 
@@ -120,13 +120,6 @@ Element.propTypes = {
   ariaLabel: PropTypes.string,
   selectOnNavigation: PropTypes.bool,
   onValueChange: PropTypes.func.isRequired,
-};
-
-Element.defaultProps = {
-  currentSortOrder: null,
-  overridableId: "",
-  ariaLabel: "Sort Order",
-  selectOnNavigation: false,
 };
 
 export default Overridable.component("SortOrder", SortOrder);

--- a/src/lib/components/Toggle/Toggle.js
+++ b/src/lib/components/Toggle/Toggle.js
@@ -13,7 +13,7 @@ import { Card, Checkbox } from "semantic-ui-react";
 import { AppContext } from "../ReactSearchKit";
 
 const ToggleComponent = ({
-  overridableId,
+  overridableId = "",
   userSelectionFilters,
   title,
   label,
@@ -60,10 +60,6 @@ ToggleComponent.propTypes = {
   /* REDUX */
   userSelectionFilters: PropTypes.array.isRequired,
   updateQueryFilters: PropTypes.func.isRequired,
-};
-
-ToggleComponent.defaultProps = {
-  overridableId: "",
 };
 
 export default Overridable.component("SearchFilters.Toggle", ToggleComponent);


### PR DESCRIPTION
- Replaces `defaultProps` with ES6 default parameter syntax across all function and pure class (render-only) components.
- React 18 deprecates `defaultProps` on function components and produces (lots of) deprecation warnings; class component `defaultProps` are intentionally preserved. See here: https://github.com/facebook/react/blob/main/CHANGELOG.md#1830-april-25-2024


Requires:
- #298

Part of: inveniosoftware/rfcs#112

### Checklist

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.