### PR TITLE
searchApi: fix response interceptors and suggestion config validation

### DIFF
--- a/src/lib/api/contrib/invenio/InvenioSearchApi.js
+++ b/src/lib/api/contrib/invenio/InvenioSearchApi.js
@@ -81,7 +81,7 @@ export class InvenioSearchApi {
       );
     }
     if (this.responseInterceptor) {
-      this.http.interceptors.request.use(
+      this.http.interceptors.response.use(
         this.responseInterceptor.resolve,
         this.responseInterceptor.reject
       );

--- a/src/lib/api/contrib/invenio/InvenioSearchApi.test.js
+++ b/src/lib/api/contrib/invenio/InvenioSearchApi.test.js
@@ -76,4 +76,36 @@ describe("test InvenioSearchApi class", () => {
     const request = mockedAxios.history.get[0];
     expect(request.url).toBe("/api/records");
   });
+
+  it("should register response interceptors on the response pipeline", async () => {
+    const responseResolve = jest.fn((response) => response);
+    const searchApi = new InvenioSearchApi({
+      axios: {
+        url: "/api/records",
+      },
+      invenio: {
+        requestSerializer: MockedRequestSerializer,
+        responseSerializer: MockedResponseSerializer,
+      },
+      interceptors: {
+        response: {
+          resolve: responseResolve,
+          reject: (error) => Promise.reject(error),
+        },
+      },
+    });
+    const mockedAxios = new MockAdapter(searchApi.http);
+
+    const mockedResponse = { hits: [{ result: "1" }] };
+    mockedAxios.onAny().reply(200, mockedResponse);
+    await searchApi.search({ q: "test" });
+
+    expect(responseResolve).toHaveBeenCalledTimes(1);
+    expect(responseResolve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 200,
+        data: mockedResponse,
+      })
+    );
+  });
 });

--- a/src/lib/api/contrib/invenio/InvenioSuggestionApi.js
+++ b/src/lib/api/contrib/invenio/InvenioSuggestionApi.js
@@ -58,8 +58,9 @@ class InvenioSuggestionResponseSerializer {
 
 export class InvenioSuggestionApi extends InvenioSearchApi {
   validateConfig(config) {
-    super.validateConfig(config);
-
+    // the parent `axios` config is already validated by the `InvenioSearchApi`
+    // constructor via `validateAxiosConfig`, here we only validate the
+    // suggestion-specific config
     if (!_hasIn(config, "invenio.suggestions.queryField")) {
       throw new Error(
         "InvenioSuggestionApi config: `invenio.suggestions.queryField` is required."
@@ -67,12 +68,13 @@ export class InvenioSuggestionApi extends InvenioSearchApi {
     }
     if (!_hasIn(config, "invenio.suggestions.responseField")) {
       throw new Error(
-        "InvenioSuggestionApi config: `invenio.suggestions.queryField` is responseField."
+        "InvenioSuggestionApi config: `invenio.suggestions.responseField` is required."
       );
     }
   }
 
   initSerializers(config) {
+    this.validateConfig(config);
     const requestSerializerCls = _get(
       config,
       "invenio.requestSerializer",

--- a/src/lib/api/contrib/invenio/InvenioSuggestionApi.test.js
+++ b/src/lib/api/contrib/invenio/InvenioSuggestionApi.test.js
@@ -1,0 +1,64 @@
+/*
+ * This file is part of React-SearchKit.
+ * Copyright (C) 2019 CERN.
+ *
+ * React-SearchKit is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT License; see LICENSE file for more details.
+ */
+
+import { InvenioSuggestionApi } from ".";
+
+describe("test InvenioSuggestionApi class", () => {
+  it("should throw when `invenio.suggestions.queryField` is missing", () => {
+    expect(
+      () =>
+        new InvenioSuggestionApi({
+          axios: {
+            url: "/api/records",
+          },
+          invenio: {
+            suggestions: {
+              responseField: "metadata.title",
+            },
+          },
+        })
+    ).toThrow(
+      "InvenioSuggestionApi config: `invenio.suggestions.queryField` is required."
+    );
+  });
+
+  it("should throw when `invenio.suggestions.responseField` is missing", () => {
+    expect(
+      () =>
+        new InvenioSuggestionApi({
+          axios: {
+            url: "/api/records",
+          },
+          invenio: {
+            suggestions: {
+              queryField: "title",
+            },
+          },
+        })
+    ).toThrow(
+      "InvenioSuggestionApi config: `invenio.suggestions.responseField` is required."
+    );
+  });
+
+  it("should not throw when both suggestion fields are provided", () => {
+    expect(
+      () =>
+        new InvenioSuggestionApi({
+          axios: {
+            url: "/api/records",
+          },
+          invenio: {
+            suggestions: {
+              queryField: "title",
+              responseField: "metadata.title",
+            },
+          },
+        })
+    ).not.toThrow();
+  });
+});

--- a/src/lib/api/contrib/opensearch/OSSearchApi.js
+++ b/src/lib/api/contrib/opensearch/OSSearchApi.js
@@ -64,7 +64,7 @@ export class OSSearchApi {
       );
     }
     if (this.responseInterceptor) {
-      this.http.interceptors.request.use(
+      this.http.interceptors.response.use(
         this.responseInterceptor.resolve,
         this.responseInterceptor.reject
       );

--- a/src/lib/api/contrib/opensearch/OSSearchApi.test.js
+++ b/src/lib/api/contrib/opensearch/OSSearchApi.test.js
@@ -76,4 +76,36 @@ describe("test OSSearchApi class", () => {
     const request = mockedAxios.history.post[0];
     expect(request.url).toBe("/api/records");
   });
+
+  it("should register response interceptors on the response pipeline", async () => {
+    const responseResolve = jest.fn((response) => response);
+    const searchApi = new OSSearchApi({
+      axios: {
+        url: "/api/records",
+      },
+      os: {
+        requestSerializer: MockedRequestSerializer,
+        responseSerializer: MockedResponseSerializer,
+      },
+      interceptors: {
+        response: {
+          resolve: responseResolve,
+          reject: (error) => Promise.reject(error),
+        },
+      },
+    });
+    const mockedAxios = new MockAdapter(searchApi.http);
+
+    const mockedResponse = { hits: [{ result: "1" }] };
+    mockedAxios.onAny().reply(200, mockedResponse);
+    await searchApi.search({ q: "test" });
+
+    expect(responseResolve).toHaveBeenCalledTimes(1);
+    expect(responseResolve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 200,
+        data: mockedResponse,
+      })
+    );
+  });
 });

--- a/src/lib/state/actions/query.js
+++ b/src/lib/state/actions/query.js
@@ -199,7 +199,7 @@ const updateQueryStateAfterResponse = (response, dispatch, getState, appConfig) 
     // Replace the URL args with the response new query state
     urlHandlerApi.replace(updatedQueryState);
   }
-  delete response.newStateQuery;
+  delete response.newQueryState;
   return response;
 };
 


### PR DESCRIPTION
:heart: Thank you for your contribution!
### Description
This PR fixes some bugs in the search API layer.

## Response Interceptors
InvenioSearchApi and OSSearchApi registered config.interceptors.response on axios.interceptors.request instead of .response, so response interceptors never ran. Now, both APIs use interceptors. response.use, with tests asserting that the handler receives {status, data}.

## InvenioSuggestionApi config
validateConfig was orphaned after the parent renamed validateConfig to validateAxiosConfig (commit in 2020) and was never called from the constructor path.

## Query state 
updateQueryStateAfterResponse deleted response.newStateQuery instead of response.newQueryState

## Impact
Bundled demos (e.g. OpenSearch on localhost:5000) behave the same on the default path, I think the fixes matters only (correct me if wrong!) when anyone who uses it uses response interceptors.
Besides adding tests, I too tested manually by adding some silly mock interceptor and verified via console logs that it indeed was being included in the logic when searching. 
### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation. (No doc changes)
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/). (No translation changes)
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines. (No frontend changes)
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines. (No frontend changes)
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines. (No frontend changes)


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
