### PR TITLE
pagination: activate page items with Space key

### DIFF
--- a/src/lib/components/Pagination/Pagination.js
+++ b/src/lib/components/Pagination/Pagination.js
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2018-2022 CERN.
+ * SPDX-FileCopyrightText: 2018-2026 CERN.
  * SPDX-License-Identifier: MIT
  */
 
@@ -9,6 +9,21 @@ import Overridable from "react-overridable";
 import { Pagination as Paginator } from "semantic-ui-react";
 import { AppContext } from "../ReactSearchKit";
 import { ShouldRender } from "../ShouldRender";
+
+const a11yPaginationItem = (Item, itemProps) => (
+  <Item
+    {...itemProps}
+    role="button"
+    onKeyDown={(event) => {
+      // ARIA button pattern: activate on "Space" in addition to "Enter".
+      // Mirrors the existing "Enter" handling in semantic-ui-react's PaginationItem.
+      if (event.key === " " && !itemProps.disabled) {
+        event.preventDefault(); // prevent page scroll
+        itemProps.onClick(event, itemProps);
+      }
+    }}
+  />
+);
 
 const defaultOptions = {
   boundaryRangeCount: 1,
@@ -141,6 +156,7 @@ const Element = ({
         lastItem={showLast ? undefined : null}
         prevItem={showPrev ? undefined : null}
         nextItem={showNext ? undefined : null}
+        pageItem={a11yPaginationItem}
         size={size}
         {...props}
       />

--- a/src/lib/components/Pagination/Pagination.test.js
+++ b/src/lib/components/Pagination/Pagination.test.js
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: 2026 CERN.
+ * SPDX-License-Identifier: MIT
+ */
+import { mount } from "enzyme";
+import React from "react";
+import { AppContext } from "../ReactSearchKit/AppContext";
+import Pagination from "./Pagination";
+
+describe("test Pagination component", () => {
+  const mountPagination = (mockUpdateQueryPage) =>
+    mount(
+      <AppContext.Provider value={{ buildUID: (id) => id }}>
+        <Pagination
+          currentPage={1}
+          currentSize={10}
+          loading={false}
+          totalResults={50}
+          updateQueryPage={mockUpdateQueryPage}
+        />
+      </AppContext.Provider>
+    );
+
+  const findPageItem = (wrapper, page) =>
+    wrapper
+      .find("a.item")
+      .filterWhere(
+        (node) => node.prop("value") === page && node.prop("type") === "pageItem"
+      );
+
+  it("should change page when 'Space' is pressed on a page item", () => {
+    const mockUpdateQueryPage = jest.fn();
+    const mockPreventDefault = jest.fn();
+    const wrapper = mountPagination(mockUpdateQueryPage);
+
+    findPageItem(wrapper, 2).simulate("keydown", {
+      key: " ",
+      preventDefault: mockPreventDefault,
+    });
+
+    expect(mockUpdateQueryPage).toHaveBeenCalledWith(2);
+    // page scroll on "Space" should be prevented
+    expect(mockPreventDefault).toHaveBeenCalled();
+  });
+
+  it("should still change page when 'Enter' is pressed on a page item", () => {
+    const mockUpdateQueryPage = jest.fn();
+    const wrapper = mountPagination(mockUpdateQueryPage);
+
+    findPageItem(wrapper, 3).simulate("keydown", {
+      key: "Enter",
+      keyCode: 13,
+      which: 13,
+    });
+
+    expect(mockUpdateQueryPage).toHaveBeenCalledWith(3);
+  });
+
+  it("should expose page items with a 'button' role", () => {
+    const wrapper = mountPagination(jest.fn());
+
+    expect(findPageItem(wrapper, 2).prop("role")).toEqual("button");
+  });
+});


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

Fixes #295

## Root cause

Pagination page items are rendered by semantic-ui-react's `Pagination` as anchors without `href` and without an explicit `role`:

```html
<a class="item" aria-current="false" aria-disabled="false" tabindex="0" value="2" type="pageItem">2</a>
```

An anchor without `href` has no native keyboard activation, so semantic-ui-react makes it focusable with `tabindex="0"` and wires up keyboard activation manually in `PaginationItem`. However, only "Enter" is handled:

```js
_this.handleKeyDown = function (e) {
  _invoke(_this.props, 'onKeyDown', e, _this.props);
  if (keyboardKey.getCode(e) === keyboardKey.Enter)
    _invoke(_this.props, 'onClick', e, _this.props);
};
```

Since these items behave as buttons (they trigger an action rather than navigate to a URL), the [ARIA APG button pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/) applies: they should be activatable with both "Enter" and "Space".

## Fix

The root cause lives in semantic-ui-react, but it can be remediated on the react-searchkit side. This PR passes a custom render function to the `pageItem` shorthand that:

- handles "Space" on `keydown` by invoking the same `onClick` that semantic-ui-react injects into the item props, mirroring its existing "Enter" handling
- calls `preventDefault()` to avoid the default page scroll on "Space"
- adds `role="button"` so the announced semantics match the behavior for assistive technologies
- ignores disabled items

Mouse and "Enter" activation are unchanged.

## Scope

The fix is intentionally scoped to page items, as reported in the issue. The first/prev/next/last arrow items share the same underlying limitation, but customizing them through the shorthand render function drops their default content (icons), so extending the fix to them would require rebuilding those defaults. Happy to address that in a follow-up if there is interest.

Note: using an item shorthand render function triggers a semantic-ui-react v3 deprecation warning in the test output. v3 was never released, this repo pins v2, and there is no alternative API to customize pagination items.

## How to verify

1. Run the OpenSearch demo (`docker-compose up` in `src/demos/opensearch/docker`, load the demo data, `npm start`)
2. Perform a search, then use Tab to focus a pagination page number
3. Press "Space": the page changes and the window does not scroll (previously: nothing happened)
4. Press "Enter": still changes the page
5. Mouse clicks: unchanged

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
